### PR TITLE
Improve the input fields so that they don't emit <div></div>

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -70,17 +70,16 @@
     "@xstate/react": "^1.0.1",
     "classnames": "^2.2.6",
     "graphql": "^15.3.0",
+    "human-id": "^2.0.1",
     "immer": "^7.0.9",
     "react": "16.13.1",
     "react-ace": "^9.1.4",
-    "react-contenteditable": "^3.3.5",
     "react-dom": "16.13.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^3",
     "tailwindcss": "^1.8.10",
     "ts-node-dev": "^1.0.0",
     "typescript": "^4.0.3",
-    "human-id": "^2.0.1",
     "xstate": "^4.13.0"
   }
 }

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -11,9 +11,9 @@ import {
   SequenceDiagramWrapper,
 } from "./components/SequenceDiagram";
 import { useEffect, useMemo } from "react";
-import ContentEditable from "react-contenteditable";
 import { useHistory, Link } from "react-router-dom";
 import { useSearchParams } from "./components/useSearchParams";
+import {Input} from "./components/Input";
 
 const HomePage = () => {
   const history = useHistory();
@@ -91,10 +91,13 @@ const HomePage = () => {
             <div className="flex overflow-hidden flex-grow">
               <div className="space-y-6 flex-col p-6 flex-1 overflow-y-auto">
                 <div>
-                  <ContentEditable
-                    className="text-2xl inline-block"
-                    html={service?.name}
-                    tagName="h1"
+                  <Input
+                    label="Service Name"
+                    classNames={{
+                      wrapper: "inline-block",
+                      input: "text-2xl"
+                    }}
+                    value={service?.name}
                     onChange={(e) => {
                       dispatch({
                         type: "UPDATE_SERVICE_NAME",
@@ -102,10 +105,10 @@ const HomePage = () => {
                         serviceId: selectedServiceId,
                       });
                     }}
-                  ></ContentEditable>
-                  <ContentEditable
-                    html={service?.description || ""}
-                    tagName="p"
+                  ></Input>
+                  <Input
+                    label="Service Description"
+                    value={service?.description || ""}
                     onChange={(e) => {
                       dispatch({
                         type: "UPDATE_SERVICE_DESCRIPTION",
@@ -113,8 +116,11 @@ const HomePage = () => {
                         serviceId: selectedServiceId,
                       });
                     }}
-                    className="text-xs text-gray-700 mt-1 leading-relaxed"
-                  ></ContentEditable>
+                    classNames={{
+                      wrapper: "mt-1",
+                      input: "text-xs text-gray-700 leading-relaxed"
+                    }}
+                  ></Input>
                 </div>
                 {sequences.map((sequence, sequenceIndex) => {
                   return (

--- a/packages/frontend/src/components/Input.tsx
+++ b/packages/frontend/src/components/Input.tsx
@@ -1,0 +1,61 @@
+import React, {KeyboardEvent, useEffect, useMemo, useRef, useState} from 'react';
+
+interface ChangeEvent {
+  target: {
+    value: string
+  }
+  nativeEvent: React.ChangeEvent<HTMLTextAreaElement>
+}
+
+const BASE_CH_UNIT = 2.5;
+
+export const Input = (props: {
+  classNames?: {
+    input?: string,
+    wrapper?: string,
+  }
+  ignoreKeys?: Array<KeyboardEvent["key"]>
+  style?: Record<string, any>
+  label: string
+  value: string
+  onChange: (event: ChangeEvent) => void
+}) => {
+  const [textareaHeight, setTextareaHeight] = useState<number>(BASE_CH_UNIT); // ch is the measure
+  const textareaRef = useRef(null);
+  const keysToIgnore = useMemo(() => props.ignoreKeys ? new RegExp(`${props.ignoreKeys.join('|')}`, 'gi') : null, [props.ignoreKeys])
+  useEffect(() => {
+    const element: HTMLElement | null = textareaRef.current;
+    if(element) {
+      const width = (element as HTMLElement).getBoundingClientRect().width;
+      const charSize = Number(window.getComputedStyle(element).getPropertyValue('font-size').replace('px', ''));
+      const charNumberOnCurrentWidth = width / charSize;
+      const numberOfLinesOnText = props.value.length / charNumberOnCurrentWidth;
+      setTextareaHeight(Math.max(BASE_CH_UNIT ,Math.round(BASE_CH_UNIT * Math.floor(numberOfLinesOnText))) + 0.5) // some extra space
+    }
+  }, [props.value])
+
+  return (<div
+    className={"flex items-center appearance-none break-all mx-0 " + props.classNames?.wrapper || ''}>
+      <textarea
+        ref={textareaRef}
+        className={"appearance-none break-all resize-none w-full bg-transparent " + props.classNames?.input || ''}
+        aria-label={props.label}
+        value={props.value}
+        style={{
+          ...props.style || {},
+          height: textareaHeight + 'ch'
+        }}
+        onChange={(e) => {
+          if(keysToIgnore){
+          console.log('value ', e.target.value.replace(keysToIgnore, ''), e.target.value, keysToIgnore.test(e.target.value), keysToIgnore)
+          }
+          props.onChange({
+            target: {
+              value: keysToIgnore ? e.target.value.replace(keysToIgnore, '') : e.target.value // dont append the ignore keys
+            },
+            nativeEvent: e
+          })
+        }}
+      />
+  </div>)
+}

--- a/packages/frontend/src/components/SequenceDiagram.tsx
+++ b/packages/frontend/src/components/SequenceDiagram.tsx
@@ -1,10 +1,10 @@
-import { useMachine } from "@xstate/compiled/react";
+import {useMachine} from "@xstate/compiled/react";
 import React from "react";
-import ContentEditable from "react-contenteditable";
 import HeroIconPlus from "./icons/HeroIconPlus";
 import HeroIconX from "./icons/HeroIconX";
-import { sequenceDiagramMachine } from "./SequenceDiagram.machine";
-import { StepArrow } from "./StepArrow";
+import {sequenceDiagramMachine} from "./SequenceDiagram.machine";
+import {StepArrow} from "./StepArrow";
+import {Input} from "./Input";
 
 export const SequenceDiagramWrapper: React.FC<{
   title: string;
@@ -14,25 +14,28 @@ export const SequenceDiagramWrapper: React.FC<{
   onDelete: () => void;
   onDuplicate: () => void;
 }> = ({
-  children,
-  title,
-  onChangeTitle,
-  onDelete,
-  onDuplicate,
-  description,
-  onChangeDescription,
-}) => {
+        children,
+        title,
+        onChangeTitle,
+        onDelete,
+        onDuplicate,
+        description,
+        onChangeDescription,
+      }) => {
   return (
     <div className="border-2 relative">
       <div>
         <div className="border-b-2 bg-gray-100">
           <div className="flex items-center">
-            <ContentEditable
-              className="text-gray-700 font-bold text-lg flex-grow px-3 py-2 "
-              html={title}
-              tagName="h2"
+            <Input
+              label={"Diagram"}
+              classNames={{
+                wrapper: "flex-grow px-3 py-2",
+                input: "text-gray-700 font-bold text-lg"
+              }}
+              value={title}
               onChange={(e) => onChangeTitle(e.target.value)}
-            ></ContentEditable>
+            ></Input>
             <div className="px-3 flex-shrink-0">
               <button
                 onClick={onDuplicate}
@@ -42,19 +45,21 @@ export const SequenceDiagramWrapper: React.FC<{
               </button>
             </div>
           </div>
-          <ContentEditable
-            className="text-xs px-3 py-2 -mt-3 text-gray-700 leading-relaxed"
+          <Input
+            label={'Description'}
+            classNames={{
+              wrapper: "px-3 py-2 -mt-3",
+              input: "text-xs text-gray-700 leading-relaxed"
+            }}
+            value={description || ""}
             onChange={(e) => onChangeDescription(e.target.value)}
-            placeholder="Description"
-            tagName="p"
-            html={description || ""}
-          />
+          ></Input>
         </div>
         <button
           className="absolute top-0 right-0 bg-gray-600 text-white rounded-full w-4 h-4 -mt-2 -mr-2 flex justify-center items-center"
           onClick={() => onDelete()}
         >
-          <HeroIconX />
+          <HeroIconX/>
         </button>
       </div>
       <div className="px-3 py-3 overflow-x-auto">{children}</div>
@@ -96,18 +101,23 @@ export const SequenceDiagram = (props: {
         {props.environments.map((env, index) => {
           return (
             <div className="relative">
-              <ContentEditable
-                className="p-4 bg-gray-200 text-gray-800 uppercase w-48 block text-center"
-                html={env.name}
+              <Input
+                label={'Environment'}
+                classNames={{
+                  wrapper: "p-4 bg-gray-200 w-48 block",
+                  input: "text-gray-800 uppercase text-center"
+                }
+                }
+                value={env.name}
                 onChange={(e) =>
                   props.onEditEnvironment(e.target.value, env.id)
                 }
-              ></ContentEditable>
+              ></Input>
               <button
                 className="absolute top-0 right-0 bg-gray-600 text-white rounded-full w-4 h-4 -mt-2 -mr-2 flex justify-center items-center"
                 onClick={() => props.onDeleteEnvironment(env.id)}
               >
-                <HeroIconX />
+                <HeroIconX/>
               </button>
             </div>
           );
@@ -219,11 +229,15 @@ export const SequenceDiagram = (props: {
       <div className="flex space-x-6">
         {props.environments.map((env, index) => {
           return (
-            <ContentEditable
-              className="p-4 bg-gray-200 text-gray-800 uppercase w-48 block text-center"
-              html={env.name}
+            <Input
+              classNames={{
+                wrapper: "p-4 bg-gray-200 w-48 block",
+                input: "text-center text-gray-800 uppercase"
+              }}
+              label={"New Environment"}
+              value={env.name}
               onChange={(e) => props.onEditEnvironment(e.target.value, env.id)}
-            ></ContentEditable>
+            ></Input>
           );
         })}
         <button

--- a/packages/frontend/src/components/StepArrow.tsx
+++ b/packages/frontend/src/components/StepArrow.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import ContentEditable from "react-contenteditable";
 import HeroIconCheveronLeft from "./icons/HeroIconCheveronLeft";
 import HeroIconCheveronRight from "./icons/HeroIconCheveronRight";
 import HeroIconX from "./icons/HeroIconX";
+import {Input} from "./Input";
 
 export const StepArrow = (props: {
   step: {
@@ -118,12 +118,16 @@ export const EventLabel = (props: {
         style={{ transform: "translateY(calc(-50% + 1px))" }}
       >
         <div className="w-4" />
-        <ContentEditable
-          className="bg-white border-2 border-gray-600 px-2 text-xs text-gray-800 text-center flex items-center appearance-none break-all"
-          html={props.value}
-          style={{ maxWidth: "8rem" }}
-          onChange={(e) => props.onChange(e.target.value)}
-        ></ContentEditable>
+        <Input onChange={(e) => props.onChange(e.target.value)}
+               ignoreKeys={['\n', '\\t', '\\s']}
+               label="Event Label"
+               value={props.value}
+               style={{ maxWidth: "8rem" }}
+               classNames={{
+                 wrapper: 'bg-white border-2 border-gray-600',
+                 input: 'px-2 text-xs text-gray-800 text-center '
+               }}
+        ></Input>
         <button
           className="w-4 h-4 bg-gray-600 flex justify-center items-center text-white rounded-full"
           onClick={props.onDelete}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6037,11 +6037,6 @@ extsprintf@^1.2.0:
   dependencies:
     kind-of "^5.0.2"
 
-fast-deep-equal@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
-  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
-
 fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -10789,7 +10784,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.6.2, prop-types@^15.7.1, prop-types@^15.7.2:
+prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -10985,14 +10980,6 @@ react-app-polyfill@^1.0.6:
     raf "^3.4.1"
     regenerator-runtime "^0.13.3"
     whatwg-fetch "^3.0.0"
-
-react-contenteditable@^3.3.5:
-  version "3.3.5"
-  resolved "https://registry.yarnpkg.com/react-contenteditable/-/react-contenteditable-3.3.5.tgz#febff7a46570fdb2f5ff199e506c512e5924e22e"
-  integrity sha512-38A7hlRQfb2KQAQT0kIJC2YlQUU7jcyYM4eh1fj6kAYb3Hmk6hHlr0snelyxVSpPXjPdFllrnSsPkzUS5AtrEA==
-  dependencies:
-    fast-deep-equal "^2.0.1"
-    prop-types "^15.7.1"
 
 react-dev-utils@^10.2.1:
   version "10.2.1"


### PR DESCRIPTION
## Description
Introduced `<Input/>` component which is flexible and is kinda the same of `<ContentEditable/>` with the only difference that it works over a `<textarea>` element which is better for text sanitization. Also it introduces a Regexp based filter at a component level which enables the dev to remove selected types of text unicode(such as` \s, \t, \n`, just an example you can filter whatever you want).

## Requirements

- [x] Can adapt to whatever layout it is placed in
- [ ] Is flexible: grows with its text-content. (Note: this kinda works, still i have to figure out a way to do the proper calculations of size so it does not bugout, if too much text is placed the algorithm starts adding extra lines of text)

PS:  The way this components expands is simple. It just calculates how many characters('a' <--- a character) can be placed inside the current input width based on the current font size, then it just does a division to know how many lines the current text should take(its just an estimation, thats why there is problems. Maybe someone who knows maths better than me can figure this out haha; im sure it is not that complicated anyways ill still look at way to do this)

@mattpocock @ezhikov (I'm tagging you guys bc maybe you'll know better)